### PR TITLE
fix numpy warning on copied non-writable arrays

### DIFF
--- a/aerial/model.py
+++ b/aerial/model.py
@@ -176,7 +176,7 @@ def train(transactions: pd.DataFrame, autoencoder: AutoEncoder = None, noise_fac
     autoencoder.train()
     autoencoder.input_vectors = input_vectors
 
-    input_vectors = input_vectors.to_numpy(dtype=np.float32, copy=False)
+    input_vectors = input_vectors.to_numpy(dtype=np.float32, copy=True)
 
     autoencoder.feature_value_indices = feature_value_indices
     autoencoder.feature_values = columns

--- a/aerial/rule_extraction.py
+++ b/aerial/rule_extraction.py
@@ -89,7 +89,7 @@ def _apply_post_filters(result, autoencoder, min_confidence, min_support, qualit
         return {'rules': [], 'statistics': {}}
 
     # Recalculate coverage
-    transaction_array = autoencoder.input_vectors.to_numpy()
+    transaction_array = autoencoder.input_vectors.to_numpy(copy=True)
     coverage = np.zeros(len(transaction_array), dtype=bool)
     for rule in filtered:
         indices = [autoencoder.feature_values.index(f"{a['feature']}__{a['value']}") for a in rule['antecedents']]
@@ -206,7 +206,7 @@ def _generate_rules_core(autoencoder, features_of_interest, min_rule_frequency, 
         return {'rules': [], 'statistics': {}}
 
     # Calculate quality metrics
-    transaction_array = autoencoder.input_vectors.to_numpy()
+    transaction_array = autoencoder.input_vectors.to_numpy(copy=True)
     num_transactions = len(transaction_array)
 
     all_metrics = calculate_rule_metrics(
@@ -342,7 +342,7 @@ def generate_frequent_itemsets(autoencoder: AutoEncoder, features_of_interest=No
 
     # Calculate support using batch processing with optional parallelization
     logger.info("Calculating support values")
-    transaction_array = autoencoder.input_vectors.to_numpy()
+    transaction_array = autoencoder.input_vectors.to_numpy(copy=True)
     num_transactions = len(transaction_array)
 
     # Batch calculate support for all itemsets (with optional parallelization)

--- a/tests/test_rule_quality.py
+++ b/tests/test_rule_quality.py
@@ -155,7 +155,7 @@ class TestRuleQualityFromIndices(unittest.TestCase):
             'Size': ['S', 'S', 'M', 'M', 'S', 'M'],
         })
         self.model = train(self.transactions, epochs=2)
-        self.transaction_array = self.model.input_vectors.to_numpy()
+        self.transaction_array = self.model.input_vectors.to_numpy(copy=True)
         self.num_transactions = len(self.transaction_array)
 
     def test_calculate_rule_quality_with_default_metrics(self):


### PR DESCRIPTION
fix numpy warning on copied non-writable arrays